### PR TITLE
Release pypi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: python
 
+notifications:
+  email: false
+
 python:
    - "3.6"
    - "3.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,26 @@
 language: python
+
 env:
-- TOXENV=py27
 - TOXENV=py36
+- TOXENV=py37
+- TOXENV=py38
+
+matrix:
+  allow_failures:
+    - TOXENV=py38
+
 install: pip install tox
 script: tox
 services:
   - redis-server
+
+deploy:
+  provider: pypi
+  user: inveniosoftware
+  password:
+    secure: "jhM7LIYWXbVPrdm2c+by+HZGJ6RrLDcaWGbnVt0foFvZRmrfq79GZqVjAaPerUqq/FLX6TggRAU1U863CszhlaNxpBB2W1Pgn8aMYA+O084IfR8YZvDzcp473djMBvTWsSX63FWXwVNcDwuRvwWDTiecz+3V4aDzLu99wPV5dERUYMKzU/n/4QdwWJnGXeNMLGBQc+t966Fyg3xPs7OIldWk0tkVucAwuZVYFSL/L8OeVIj6x76JmhK/my+cxP9eStui+btJWooY0hZQ0A1J3o7RMc0sywDO0xMeUEth7tjeIOj+id03o6MuU4jTbEeYhjGp5sdQNweWq9QN7BRugjr3BR0MVeml7xlBGoJjsm5u/FNfSwOzYKHzF2S3ApC0mJCiZdZB+/bvUjj2fID8mZ7PrKy6P1UnlxLveTU07eoGi/fTz6GJ0tAB20/vm+OVdv8/1PaTUhwfh0gBp4lVC/j/7N3DdyMG87+5ZOQ26Xc43KTDMQmn5qNCpdEC1IyV8ubwgtjzen7Pbu2pL4/STwtfUpGhx3LS0ugAFXwAQkdAj23f1oShQ2WiYuoA3L2HWkX5YdGYGcQFaokztschAlxGEPjjWxBh2W6u1hl6/ikfCMognnHyQEBzneRkFJFeIgpUkXs53wd7hcR1uTO+9vh5jG0idtdbknvK/ScVsYI="
+  distributions: "compile_catalog sdist bdist_wheel"
+  on:
+    tags: true
+    repo: inveniosoftware/Flask-KVSession-Invenio
+  skip_existing: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ deploy:
   user: inveniosoftware
   password:
     secure: "jhM7LIYWXbVPrdm2c+by+HZGJ6RrLDcaWGbnVt0foFvZRmrfq79GZqVjAaPerUqq/FLX6TggRAU1U863CszhlaNxpBB2W1Pgn8aMYA+O084IfR8YZvDzcp473djMBvTWsSX63FWXwVNcDwuRvwWDTiecz+3V4aDzLu99wPV5dERUYMKzU/n/4QdwWJnGXeNMLGBQc+t966Fyg3xPs7OIldWk0tkVucAwuZVYFSL/L8OeVIj6x76JmhK/my+cxP9eStui+btJWooY0hZQ0A1J3o7RMc0sywDO0xMeUEth7tjeIOj+id03o6MuU4jTbEeYhjGp5sdQNweWq9QN7BRugjr3BR0MVeml7xlBGoJjsm5u/FNfSwOzYKHzF2S3ApC0mJCiZdZB+/bvUjj2fID8mZ7PrKy6P1UnlxLveTU07eoGi/fTz6GJ0tAB20/vm+OVdv8/1PaTUhwfh0gBp4lVC/j/7N3DdyMG87+5ZOQ26Xc43KTDMQmn5qNCpdEC1IyV8ubwgtjzen7Pbu2pL4/STwtfUpGhx3LS0ugAFXwAQkdAj23f1oShQ2WiYuoA3L2HWkX5YdGYGcQFaokztschAlxGEPjjWxBh2W6u1hl6/ikfCMognnHyQEBzneRkFJFeIgpUkXs53wd7hcR1uTO+9vh5jG0idtdbknvK/ScVsYI="
-  distributions: "compile_catalog sdist bdist_wheel"
+  distributions: "sdist bdist_wheel"
   on:
     tags: true
     repo: inveniosoftware/Flask-KVSession-Invenio

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,4 @@ deploy:
   distributions: "sdist bdist_wheel"
   on:
     tags: true
-    repo: inveniosoftware/Flask-KVSession-Invenio
   skip_existing: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: python
 
-env:
-- TOXENV=py36
-- TOXENV=py37
-- TOXENV=py38
+python:
+   - "3.6"
+   - "3.7"
+   - "3.8"
 
 matrix:
   allow_failures:
-    - TOXENV=py38
+    - python: 3.8
 
 install: pip install tox
 script: tox

--- a/flask_kvsession/version.py
+++ b/flask_kvsession/version.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Flask-KVSession
+# Copyright (C) 2013, 2014, 2015, 2016 CERN.
+#
+# Flask-Menu is free software; you can redistribute it and/or modify
+# it under the terms of the Revised BSD License; see LICENSE file for
+# more details.
+
+"""Version information for Flask-KVSession."""
+
+__version__ = "0.6.3"

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,8 @@ def read(fname):
 
 
 setup(
-    name='Flask-KVSession',
-    version='0.6.3.dev1',
+    name='Flask-KVSession-Invenio',
+    version='0.6.3',
     url='https://github.com/mbr/flask-kvsession',
     license='MIT',
     author='Marc Brinkmann',
@@ -26,11 +26,15 @@ setup(
     zip_safe=False,
     platforms='any',
     install_requires=[
-        'Flask>=0.8', 'simplekv>=0.9.2', 'werkzeug', 'itsdangerous>=0.20',
+        'Flask>=0.8',
+        'itsdangerous>=0.20',
+        'simplekv>=0.9.2',
         'six',
+        'werkzeug',
     ],
     classifiers=[
-        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33
+envlist = py36, py37, py38
 
 [testenv]
 deps=

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,3 @@
-[tox]
-envlist = py36, py37, py38
-
 [testenv]
 deps=
   pytest


### PR DESCRIPTION
Changes:

- Update python versions
- Add `version.py` file. Starting on v0.6.3, since the latest on https://github.com/mbr/flask-kvsession is 0.6.2
- Named according to issue: inveniosoftware/Flask-KVSession-Invenio

Tests are passing: https://travis-ci.org/github/ppanero/flask-kvsession/builds/683756756 Will eventually pass here when travis has time.

Closes https://github.com/inveniosoftware/flask-kvsession/issues/3
Closes https://github.com/inveniosoftware/flask-kvsession/issues/5